### PR TITLE
Fix #9 Catastrophic backtracking na hora de encontrar o CNJ

### DIFF
--- a/cnjfacil/extrator.py
+++ b/cnjfacil/extrator.py
@@ -44,11 +44,12 @@ class ExtratorCNJ:
 
     def _valida_ano_do_cnj(self):
         limite_inferior = 1895  # Ano do primeiro processo ajuizado do Brasil
-        limite_superior = datetime.datetime.utcnow().year
+        limite_superior = datetime.datetime.utcnow().year + 2  # Dois anos na frente
         self._cnjs = filter(
-            lambda cnj: int(cnj[11::][:4]) < limite_superior and int(cnj[11::][:4]) > limite_inferior,
+            lambda cnj: int(cnj[11::][:4]) <= limite_superior and int(cnj[11::][:4]) >= limite_inferior,
             self._cnjs
         )
+        self._cnjs = list(self._cnjs)
 
     def _busca_cnjs(self):
         cnjs = self._buscador.findall(self.texto)

--- a/cnjfacil/extrator.py
+++ b/cnjfacil/extrator.py
@@ -15,6 +15,8 @@ class ExtratorCNJ:
         Texto (str): Texto em que os CNJs serão encontrados
     """
 
+    LOOKBEHIND = r'(?:(?<=\A)|(?<=[\sA-ü:ºª°.\-]))'
+
     ORDEM = r'\d\s*\d?\s*\d?\s*\d?\s*\d?\s*\d?\s*\d?\s*'
     VERIFICADOR = r'[- .]?\d\s*\d\s*'
     ANO = r'\.?\d\s*\d\s*\d\s*\d\s*'
@@ -22,7 +24,7 @@ class ExtratorCNJ:
     TRIBUNAL = r'\.?\d\s*\d\s*'
     ORIGEM = r'\.?\d\s*\d\s*\d\s*\d'
     REGEX = re.compile(''.join(
-        [ORDEM, VERIFICADOR, ANO, DIGITO, TRIBUNAL, ORIGEM]))
+        [LOOKBEHIND, ORDEM, VERIFICADOR, ANO, DIGITO, TRIBUNAL, ORIGEM]))
     FORMATO_CNJ = re.compile(r'(\d{7}-\d{2}\.\d{4}\.\d\.\d{2}\.\d{4})')
 
     def __init__(self, texto, maximo_tentativas=10):

--- a/cnjfacil/testes/extrator.py
+++ b/cnjfacil/testes/extrator.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+import datetime
 from unittest import TestCase
 
 from cnjfacil.extrator import ExtratorCNJ
@@ -72,3 +73,15 @@ class ExtratorTestCase(TestCase):
         '''
         extrator = ExtratorCNJ(texto)
         self.assertEqual(extrator.cnjs, ['0053087-35.2013.8.13.0693'])
+
+    def test_valida_cnj_ano_atual(self):
+        ano = datetime.datetime.utcnow().year
+        cnj = '0053087-35.{}.8.13.0693'.format(ano)
+        extrator = ExtratorCNJ(cnj)
+        self.assertEqual(extrator.cnjs, [cnj])
+
+    def test_valida_cnj_ano_no_futuro_proximo(self):
+        ano_proximo = datetime.datetime.utcnow().year + 2
+        cnj = '0053087-35.{}.8.13.0693'.format(ano_proximo)
+        extrator = ExtratorCNJ(cnj)
+        self.assertEqual(extrator.cnjs, [cnj])

--- a/cnjfacil/testes/extrator.py
+++ b/cnjfacil/testes/extrator.py
@@ -85,3 +85,17 @@ class ExtratorTestCase(TestCase):
         cnj = '0053087-35.{}.8.13.0693'.format(ano_proximo)
         extrator = ExtratorCNJ(cnj)
         self.assertEqual(extrator.cnjs, [cnj])
+
+    def test_cnjs_extracao_com_lookbehind(self):
+        texto = '*** DGJUR - SECRETARIA DA 10ª CÂMARA CÍVEL *** ATO ORDINATÓRIO 010. AGRAVO DE'\
+            'INSTRUMENTO - CÍVEL 0077777-12.2020.8.19.0000    R$       40552                     '\
+            '                                                            Rio de Janeiro 24 de '\
+            'janeiro de 2020'\
+            'nº0011111-12.2020.8.19.0000 nª0022222-12.2020.8.19.0000 n°0033333-12.2020.8.19.0000'
+        extrator = ExtratorCNJ(texto)
+        self.assertEqual(set(extrator.cnjs), set([
+            '0022222-12.2020.8.19.0000',
+            '0011111-12.2020.8.19.0000',
+            '0077777-12.2020.8.19.0000',
+            '0033333-12.2020.8.19.0000',
+        ]))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='CNJFacil',
-    version='0.1.5',
+    version='0.1.6',
     author='Marcus Bodock',
     author_email='mbodock@gmail.com',
     packages=['cnjfacil'],


### PR DESCRIPTION
Para resolver o problema:
- adicionamos um LOOKBEHIND no início da regex
- este LOOKBEHIND tivemos que colocar alguns casos de uso de como os CNJs tem aparecido nos textos dos processos atualmente

Além da correção da issue, também fiz uma otimização na validação da ano da issue #4 .

- Passei a considerar 2 anos a mais do que o ano atual como válido também. Um ano a mais eu coloquei pois no final do ano pode sair processo com data do próximo ano. E outro ano a mais foi só para garantir mesmo.
- O `filter` da validação do ano não estava retornando uma `list` nos testes no `python 3.5+`, então forcei o cast to `list`.

(Com colaboração de @pipibodock )